### PR TITLE
Changed enum type ReadingTipCategory to use constants in a more readable way

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ Taski on valmis, kun sitä vastaava koodi on dokumentoitu, vastaa user storya, s
 * [Heroku demo](https://takarivi-lukuvinkit.herokuapp.com/) (päivitetään toisinaan, yleensä ainakin sprinttien lopussa)
 * [Cucumber-testit](https://github.com/ohtu-takarivi/lukuvinkit/tree/master/src/test/resources/ohtu/takarivi/lukuvinkit)
 
+
+
+

--- a/src/main/java/ohtu/takarivi/lukuvinkit/domain/ReadingTipCategory.java
+++ b/src/main/java/ohtu/takarivi/lukuvinkit/domain/ReadingTipCategory.java
@@ -23,8 +23,11 @@ public enum ReadingTipCategory {
             case "links":
                 return LINK;
             default:
-                try { return ReadingTipCategory.valueOf(category.toUpperCase()); } 
-                catch (IllegalArgumentException ex) { return null; }    
+                try { 
+                    return ReadingTipCategory.valueOf(category.toUpperCase()); 
+                } catch (IllegalArgumentException ex) { 
+                    return null; 
+                }    
         }
     }
 }

--- a/src/main/java/ohtu/takarivi/lukuvinkit/domain/ReadingTipCategory.java
+++ b/src/main/java/ohtu/takarivi/lukuvinkit/domain/ReadingTipCategory.java
@@ -13,19 +13,18 @@ public enum ReadingTipCategory {
      * @return The correct ReadingTipCategory value, or null if no such category was found.
      */
     public static ReadingTipCategory getByName(String category) {
-        if (category.equalsIgnoreCase("books")) {
-            return BOOK;
-        } else if (category.equalsIgnoreCase("articles")) {
-            return ARTICLE;
-        } else if (category.equalsIgnoreCase("videos")) {
-            return VIDEO;
-        } else if (category.equalsIgnoreCase("links")) {
-            return LINK;
-        }
-        try {
-            return ReadingTipCategory.valueOf(category.toUpperCase());
-        } catch (IllegalArgumentException ex) {
-            return null;
+        switch (category.toLowerCase()) {
+            case "books":
+                return BOOK;
+            case "articles":
+                return ARTICLE;
+            case "videos":
+                return VIDEO;
+            case "links":
+                return LINK;
+            default:
+                try { return ReadingTipCategory.valueOf(category.toUpperCase()); } 
+                catch (IllegalArgumentException ex) { return null; }    
         }
     }
 }

--- a/src/main/java/ohtu/takarivi/lukuvinkit/forms/ReadingTipAddForm.java
+++ b/src/main/java/ohtu/takarivi/lukuvinkit/forms/ReadingTipAddForm.java
@@ -60,16 +60,17 @@ public class ReadingTipAddForm extends AddForm {
      */
     public ReadingTip createReadingTip(CustomUser customUser, ReadingTipTagRepository readingTipTagRepository) {
         ReadingTipCategory readingTipCategory = ReadingTipCategory.getByName(category);
-        if (readingTipCategory == ReadingTipCategory.ARTICLE) {
-            return new ReadingTip(title, readingTipCategory, description, "", author, "", FormUtils.prepareTags(readingTipTagRepository, tags.split(" ")), customUser);
-        } else if (readingTipCategory == ReadingTipCategory.BOOK) {
-            return new ReadingTip(title, readingTipCategory, description, "", author, isbn, FormUtils.prepareTags(readingTipTagRepository, tags.split(" ")), customUser);
-        } else if (readingTipCategory == ReadingTipCategory.LINK) {
-            return new ReadingTip(title, readingTipCategory, description, url, author, "", FormUtils.prepareTags(readingTipTagRepository, tags.split(" ")), customUser);
-        } else if (readingTipCategory == ReadingTipCategory.VIDEO) {
-            return new ReadingTip(title, readingTipCategory, description, url, author, "", FormUtils.prepareTags(readingTipTagRepository, tags.split(" ")), customUser);
-        } else {
-            return null;
+        switch (readingTipCategory) {
+            case ARTICLE:
+                return new ReadingTip(title, readingTipCategory, description, "", author, "", FormUtils.prepareTags(readingTipTagRepository, tags.split(" ")), customUser);
+            case BOOK:
+                return new ReadingTip(title, readingTipCategory, description, "", author, isbn, FormUtils.prepareTags(readingTipTagRepository, tags.split(" ")), customUser);
+            case LINK:
+                return new ReadingTip(title, readingTipCategory, description, url, author, "", FormUtils.prepareTags(readingTipTagRepository, tags.split(" ")), customUser);
+            case VIDEO:
+                return new ReadingTip(title, readingTipCategory, description, url, author, "", FormUtils.prepareTags(readingTipTagRepository, tags.split(" ")), customUser);
+            default:
+                return null;
         }
     }
 


### PR DESCRIPTION
Changed the use of enum type ReadingTipCategory to use switch statements in the getByName method for readability and ease of use. The checks now have less copy paste and directly compare constants.